### PR TITLE
Fix #2 speed up container build use mount caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ COPY src src
 # Copy default props file
 COPY src/main/resources/props/sample.props.template src/main/resources/props/default.props
 COPY src/main/resources/container.logback.xml.example src/main/resources/default.logback.xml
-RUN mvn -e -B dependency:resolve
-RUN mvn -e -B package
+RUN --mount=type=cache,target=/root/.m2 mvn -e -B dependency:resolve
+RUN --mount=type=cache,target=/root/.m2 mvn -e -B package
 
 FROM jetty
 


### PR DESCRIPTION
Ref #2 
Perform same build optimisation to stop builds taking > 20-40 mins downloading from maven repo (same as https://github.com/OpenBankProject/OBP-API/pull/2107 ) 

```
time docker build -t api-explorer .
real    0m1.218s
user    0m0.187s
sys     0m0.061s
```

